### PR TITLE
Make xcframework available for swift project

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
+XCFRAMEWORK_DIR="./apple_xcframework"
+
 # buildStatic iphoneos -mios-version-min=15.0 arm64
 buildStatic()
 {
      echo "build for '$1', '$2', '$3'"
+
      make PP="xcrun --sdk $1 --toolchain $1 clang" \
           CC="xcrun --sdk $1 --toolchain $1 clang" \
-          CFLAGS="-arch $3 $2" \
-          LFLAGS="-arch $3 $2 -Wl,-Bsymbolic-functions" static
+          CFLAGS="-arch $2 $3" \
+          LFLAGS="-arch $2 $3 -Wl,-Bsymbolic-functions" static
 
-     local OUTPUT_ARCH_FILE="libhev-socks5-tunnel-$1-$3.a"
+     local OUTPUT_DIR="$XCFRAMEWORK_DIR/$1-$2"
+     mkdir -p $OUTPUT_DIR
+     local OUTPUT_ARCH_FILE="$OUTPUT_DIR/libhev-socks5-tunnel.a"
 
      libtool -static -o $OUTPUT_ARCH_FILE \
                    bin/libhev-socks5-tunnel.a \
@@ -21,31 +26,39 @@ buildStatic()
 
 mergeStatic()
 {
-     local AMD_LIB_FILE="libhev-socks5-tunnel-$1-x86_64.a"
-     local ARM_LIB_FILE="libhev-socks5-tunnel-$1-arm64.a"
-     local OUTPUT_LIB_FILE="libhev-socks5-tunnel-$1.a"
+     echo "merge for '$1', '$2', '$3'"
+     local FIRST_LIB_FILE="$XCFRAMEWORK_DIR/$1-$2/libhev-socks5-tunnel.a"
+     local SECOND_LIB_FILE="$XCFRAMEWORK_DIR/$1-$3/libhev-socks5-tunnel.a"
+     local OUTPUT_DIR="$XCFRAMEWORK_DIR/$1-$2-$3"
+     mkdir -p $OUTPUT_DIR
+     local OUTPUT_ARCH_FILE="$OUTPUT_DIR/libhev-socks5-tunnel.a"
      lipo -create \
-	-arch x86_64 $AMD_LIB_FILE \
-	-arch arm64  $ARM_LIB_FILE \
-	-output $OUTPUT_LIB_FILE
+          -arch $2 $FIRST_LIB_FILE \
+          -arch $3 $SECOND_LIB_FILE \
+          -output $OUTPUT_ARCH_FILE
 }
 
-buildStatic iphoneos -mios-version-min=15.0 arm64
-buildStatic iphonesimulator -miphonesimulator-version-min=15.0 x86_64
-buildStatic iphonesimulator -miphonesimulator-version-min=15.0 arm64
-mergeStatic iphonesimulator
-
-buildStatic macosx -mmacosx-version-min=12.0 x86_64
-buildStatic macosx -mmacosx-version-min=12.0 arm64
-mergeStatic macosx
-
-cp module.modulemap include/
+rm -rf $XCFRAMEWORK_DIR
 rm -rf HevSocks5Tunnel.xcframework
-xcodebuild -create-xcframework \
-    -library libhev-socks5-tunnel-iphoneos-arm64.a -headers include \
-    -library libhev-socks5-tunnel-iphonesimulator.a -headers include \
-    -library libhev-socks5-tunnel-macosx.a -headers include \
-    -output HevSocks5Tunnel.xcframework
+mkdir $XCFRAMEWORK_DIR
 
-rm -rf include/module.modulemap
-rm -rf libhev-socks5-tunnel-*.a
+buildStatic iphoneos arm64 -mios-version-min=15.0
+buildStatic iphonesimulator x86_64 -miphonesimulator-version-min=15.0
+buildStatic iphonesimulator arm64 -miphonesimulator-version-min=15.0
+mergeStatic iphonesimulator x86_64 arm64
+
+buildStatic macosx x86_64 -mmacosx-version-min=12.0
+buildStatic macosx arm64 -mmacosx-version-min=12.0
+mergeStatic macosx x86_64 arm64
+
+INCLUDE_DIR="$XCFRAMEWORK_DIR/include"
+mkdir -p $INCLUDE_DIR
+cp ./src/hev-main.h $INCLUDE_DIR
+cp ./module.modulemap $INCLUDE_DIR
+xcodebuild -create-xcframework \
+    -library ./apple_xcframework/iphoneos-arm64/libhev-socks5-tunnel.a -headers $INCLUDE_DIR \
+    -library ./apple_xcframework/iphonesimulator-x86_64-arm64/libhev-socks5-tunnel.a -headers $INCLUDE_DIR \
+    -library ./apple_xcframework/macosx-x86_64-arm64/libhev-socks5-tunnel.a -headers $INCLUDE_DIR \
+    -output ./HevSocks5Tunnel.xcframework
+
+rm -rf ./apple_xcframework

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,0 +1,4 @@
+module HevSocks5Tunnel {
+    umbrella header "hev-socks5-tunnel.h"
+    export *
+}

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,4 +1,4 @@
 module HevSocks5Tunnel {
-    umbrella header "hev-socks5-tunnel.h"
+    umbrella header "hev-main.h"
     export *
 }


### PR DESCRIPTION
The previous build.sh misses module.modulemap, which is needed for swift project. And it uses the header file in "include", which can not be read in the final xcframework.
Here is a fix.