### PR TITLE
fix build error on macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ buildStatic()
 
      make PP="xcrun --sdk $1 --toolchain $1 clang" \
           CC="xcrun --sdk $1 --toolchain $1 clang" \
-          CFLAGS="-arch $2 $3" \
+          CFLAGS="-arch $2 $3 -Wno-unused-but-set-variable" \
           LFLAGS="-arch $2 $3 -Wl,-Bsymbolic-functions" static
 
      local OUTPUT_DIR="$XCFRAMEWORK_DIR/$1-$2"


### PR DESCRIPTION
There is an error on macOS using Xcode 15 when building, because `unsigned int mark` is unsed, which is in  line 176 of **scr/hev-socks5-session-tcp.c**.
Here is a fix.