### PR TITLE
Added include for type `size_t`

### DIFF
--- a/src/hev-main.h
+++ b/src/hev-main.h
@@ -10,6 +10,8 @@
 #ifndef __HEV_MAIN_H__
 #define __HEV_MAIN_H__
 
+#include<stdio.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/hev-main.h
+++ b/src/hev-main.h
@@ -10,7 +10,7 @@
 #ifndef __HEV_MAIN_H__
 #define __HEV_MAIN_H__
 
-#include<stddef.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/hev-main.h
+++ b/src/hev-main.h
@@ -10,7 +10,7 @@
 #ifndef __HEV_MAIN_H__
 #define __HEV_MAIN_H__
 
-#include<stdio.h>
+#include<stddef.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
`size_t` Isn't a type included by default in some compilers