### PR TITLE
Add option to init config from string

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,43 @@ sudo route change -inet6 default -interface utun99
  * Start and run the socks5 tunnel, this function will blocks until the
  * hev_socks5_tunnel_quit is called or an error occurs.
  *
+ * Alias of hev_socks5_tunnel_main_from_file
+ *
  * Returns: returns zero on successful, otherwise returns -1.
  *
  * Since: 2.4.6
  */
 int hev_socks5_tunnel_main (const char *config_path, int tun_fd);
+
+/**
+ * hev_socks5_tunnel_main_from_file:
+ * @config_path: config file path
+ * @tun_fd: tunnel file descriptor
+ *
+ * Start and run the socks5 tunnel, this function will blocks until the
+ * hev_socks5_tunnel_quit is called or an error occurs.
+ *
+ * Returns: returns zero on successful, otherwise returns -1.
+ *
+ * Since: 2.6.7
+ */
+int hev_socks5_tunnel_main_from_file (const char *config_path, int tun_fd);
+
+/**
+ * hev_socks5_tunnel_main_from_str:
+ * @config_str: string config
+ * @config_len: the byte length of string config
+ * @tun_fd: tunnel file descriptor
+ *
+ * Start and run the socks5 tunnel, this function will blocks until the
+ * hev_socks5_tunnel_quit is called or an error occurs.
+ *
+ * Returns: returns zero on successful, otherwise returns -1.
+ *
+ * Since: 2.6.7
+ */
+int hev_socks5_tunnel_main_from_str (const unsigned char *config_str,
+                                     unsigned int config_len, int tun_fd);
 
 /**
  * hev_socks5_tunnel_quit:

--- a/src/hev-config.c
+++ b/src/hev-config.c
@@ -340,7 +340,7 @@ hev_config_parse_doc (yaml_document_t *doc)
 }
 
 int
-hev_config_init (const char *config_path)
+hev_config_init_from_file (const char *config_path)
 {
     yaml_parser_t parser;
     yaml_document_t doc;
@@ -367,6 +367,32 @@ hev_config_init (const char *config_path)
 
 exit_close_fp:
     fclose (fp);
+exit_free_parser:
+    yaml_parser_delete (&parser);
+exit:
+    return res;
+}
+
+int
+hev_config_init_from_str (const unsigned char *config_str,
+                          unsigned int config_len)
+{
+    yaml_parser_t parser;
+    yaml_document_t doc;
+    int res = -1;
+
+    if (!yaml_parser_initialize (&parser))
+        goto exit;
+
+    yaml_parser_set_input_string (&parser, config_str, config_len);
+    if (!yaml_parser_load (&parser, &doc)) {
+        fprintf (stderr, "Failed to parse config.");
+        goto exit_free_parser;
+    }
+
+    res = hev_config_parse_doc (&doc);
+    yaml_document_delete (&doc);
+
 exit_free_parser:
     yaml_parser_delete (&parser);
 exit:

--- a/src/hev-config.h
+++ b/src/hev-config.h
@@ -23,7 +23,9 @@ struct _HevConfigServer
     char addr[256];
 };
 
-int hev_config_init (const char *config_path);
+int hev_config_init_from_file (const char *config_path);
+int hev_config_init_from_str (const unsigned char *config_str,
+                              unsigned int config_len);
 void hev_config_fini (void);
 
 const char *hev_config_get_tunnel_name (void);

--- a/src/hev-main.c
+++ b/src/hev-main.c
@@ -40,18 +40,14 @@ sigint_handler (int signum)
     hev_socks5_tunnel_stop ();
 }
 
-int
-hev_socks5_tunnel_main (const char *config_path, int tun_fd)
+static int
+hev_socks5_tunnel_main_inner (int tun_fd)
 {
     const char *pid_file;
     const char *log_file;
     int log_level;
     int nofile;
     int res;
-
-    res = hev_config_init (config_path);
-    if (res < 0)
-        return -1;
 
     log_file = hev_config_get_misc_log_file ();
     log_level = hev_config_get_misc_log_level ();
@@ -92,6 +88,33 @@ hev_socks5_tunnel_main (const char *config_path, int tun_fd)
     hev_task_system_fini ();
 
     return 0;
+}
+
+int
+hev_socks5_tunnel_main_from_file (const char *config_path, int tun_fd)
+{
+    int res = hev_config_init_from_file (config_path);
+    if (res < 0)
+        return -1;
+
+    return hev_socks5_tunnel_main_inner (tun_fd);
+}
+
+int
+hev_socks5_tunnel_main_from_str (const unsigned char *config_str,
+                                 unsigned int config_len, int tun_fd)
+{
+    int res = hev_config_init_from_str (config_str, config_len);
+    if (res < 0)
+        return -1;
+
+    return hev_socks5_tunnel_main_inner (tun_fd);
+}
+
+int
+hev_socks5_tunnel_main (const char *config_path, int tun_fd)
+{
+    return hev_socks5_tunnel_main_from_file (config_path, tun_fd);
 }
 
 void

--- a/src/hev-main.h
+++ b/src/hev-main.h
@@ -31,6 +31,36 @@ extern "C" {
 int hev_socks5_tunnel_main (const char *config_path, int tun_fd);
 
 /**
+ * hev_socks5_tunnel_main_from_file:
+ * @config_path: config file path
+ * @tun_fd: tunnel file descriptor
+ *
+ * Start and run the socks5 tunnel, this function will blocks until the
+ * hev_socks5_tunnel_quit is called or an error occurs.
+ *
+ * Returns: returns zero on successful, otherwise returns -1.
+ *
+ * Since: 2.6.7
+ */
+int hev_socks5_tunnel_main_from_file (const char *config_path, int tun_fd);
+
+/**
+ * hev_socks5_tunnel_main_from_str:
+ * @config_str: string config
+ * @config_len: the byte length of string config
+ * @tun_fd: tunnel file descriptor
+ *
+ * Start and run the socks5 tunnel, this function will blocks until the
+ * hev_socks5_tunnel_quit is called or an error occurs.
+ *
+ * Returns: returns zero on successful, otherwise returns -1.
+ *
+ * Since: 2.6.7
+ */
+int hev_socks5_tunnel_main_from_str (const unsigned char *config_str,
+                                     unsigned int config_len, int tun_fd);
+
+/**
  * hev_socks5_tunnel_quit:
  *
  * Stop the socks5 tunnel.


### PR DESCRIPTION
Hi,

First of all thank you for writing that beautiful piece of software.

This PR adds ability to provide a config via byte array, right now I am simply passing utf8 string from Rust and that seems to work just fine.

I am not entirely sure that the formal way to add support for that is to add more args to `main()` so feel free to refine that PR if you find it useful.