### PR TITLE
mac: add HevSocks5Tunnel.xcframework to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin
 build
+HevSocks5Tunnel.xcframework


### PR DESCRIPTION
Git is dirty after running `build.sh`. I think it would make sense to add `HevSocks5Tunnel.xcframework` to gitignore to prevent untracked changes, especially a problem if the repo is attached as git submodule.