### PR TITLE
fix: remove redundant words from image names

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -134,7 +134,7 @@ jobs:
         uses: docker/metadata-action@v5
         id: docker_meta
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
`ghcr.io/heiher/heiher/hev-socks5-tunnel` => `ghcr.io/heiher/hev-socks5-tunnel`

I'm sorry for my mistake yesterday.

and need to delete the old image name manually:

1. 
   ![image](https://github.com/heiher/hev-socks5-tunnel/assets/21287731/3c2a382a-6393-406a-b689-d473bd66e348)
2. 
   ![image](https://github.com/heiher/hev-socks5-tunnel/assets/21287731/885c200e-f537-499c-8553-e773229caf73)
3.
   ![image](https://github.com/heiher/hev-socks5-tunnel/assets/21287731/b72a8788-2946-4ab6-9719-29bad07c21b7)
