### PR TITLE
Fix preprocessor directives checking TARGET_OS_TV

### DIFF
--- a/src/misc/hev-exec.c
+++ b/src/misc/hev-exec.c
@@ -22,7 +22,12 @@
 
 #include "hev-exec.h"
 
-#ifndef TARGET_OS_TV
+#if TARGET_OS_TV
+void
+hev_exec_run (const char *script_path, const char *tun_name, int wait)
+{
+}
+#else
 static void
 signal_handler (int signum)
 {
@@ -50,10 +55,5 @@ hev_exec_run (const char *script_path, const char *tun_name, int wait)
 
     LOG_E ("exec %s %s", script_path, tun_name);
     exit (-1);
-}
-#else
-void
-hev_exec_run (const char *script_path, const char *tun_name, int wait)
-{
 }
 #endif

--- a/src/misc/hev-utils.c
+++ b/src/misc/hev-utils.c
@@ -36,7 +36,7 @@ run_as_daemon (const char *pid_file)
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#ifndef TARGET_OS_TV
+#if !(TARGET_OS_TV)
     if (daemon (0, 0)) {
         /* ignore return value */
     }


### PR DESCRIPTION
My xcode has /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/TargetConditionals.h containing
```
// Make sure all TARGET_OS_* and TARGET_CPU_* values are defined
```
```
#ifndef TARGET_OS_TV
    #define TARGET_OS_TV         0
#endif
```
