### PR TITLE
Introduce `CONFIG_ROUTES` to support manual route configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,10 @@ ENV TUN=tun0 \
     SOCKS5_USERNAME='' \
     SOCKS5_PASSWORD='' \
     SOCKS5_UDP_MODE=udp \
+    CONFIG_ROUTES=1 \
     IPV4_INCLUDED_ROUTES=0.0.0.0/0 \
     IPV4_EXCLUDED_ROUTES='' \
-    LOG_LEVEL=warn \
-    BYPASS_PBR=0
+    LOG_LEVEL=warn
 
 HEALTHCHECK --start-period=5s --interval=5s --timeout=2s --retries=3 CMD ["test", "-f", "/success"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ ENV TUN=tun0 \
     SOCKS5_UDP_MODE=udp \
     IPV4_INCLUDED_ROUTES=0.0.0.0/0 \
     IPV4_EXCLUDED_ROUTES='' \
-    LOG_LEVEL=warn
+    LOG_LEVEL=warn \
+    BYPASS_PBR=0
 
 HEALTHCHECK --start-period=5s --interval=5s --timeout=2s --retries=3 CMD ["test", "-f", "/success"]
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ services:
       IPV4_INCLUDED_ROUTES: 0.0.0.0/0 # optional, demo means proxy all traffic. for multiple network segments, join with `,` or `\n`
       IPV4_EXCLUDED_ROUTES: a.b.c.d # optional, demo means exclude traffic from the proxy itself. for multiple network segments, join with `,` or `\n`
       LOG_LEVEL: warn # optional, default `warn`, other option `debug`/`info`/`error`
+      BYPASS_PBR: 0 # optional, set 1 to ignore TABLE, MARK, IPV4_INCLUDED_ROUTES and IPV4_EXCLUDED_ROUTES
     dns:
       - 8.8.8.8
 ```

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ services:
       SOCKS5_USERNAME: user # optional, socks5 proxy username, only set when need to auth
       SOCKS5_PASSWORD: pass # optional, socks5 proxy password, only set when need to auth
       SOCKS5_UDP_MODE: udp # optional, UDP relay mode, default `udp`, other option `tcp`
-      CONFIG_ROUTES: 1 # optional, set 0 to ignore TABLE, MARK, IPV4_INCLUDED_ROUTES and IPV4_EXCLUDED_ROUTES
+      CONFIG_ROUTES: 1 # optional, set 0 to ignore TABLE, IPV4_INCLUDED_ROUTES and IPV4_EXCLUDED_ROUTES, with MARK defaults to 0
       IPV4_INCLUDED_ROUTES: 0.0.0.0/0 # optional, demo means proxy all traffic. for multiple network segments, join with `,` or `\n`
       IPV4_EXCLUDED_ROUTES: a.b.c.d # optional, demo means exclude traffic from the proxy itself. for multiple network segments, join with `,` or `\n`
       LOG_LEVEL: warn # optional, default `warn`, other option `debug`/`info`/`error`

--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ services:
       SOCKS5_USERNAME: user # optional, socks5 proxy username, only set when need to auth
       SOCKS5_PASSWORD: pass # optional, socks5 proxy password, only set when need to auth
       SOCKS5_UDP_MODE: udp # optional, UDP relay mode, default `udp`, other option `tcp`
+      CONFIG_ROUTES: 1 # optional, set 0 to ignore TABLE, MARK, IPV4_INCLUDED_ROUTES and IPV4_EXCLUDED_ROUTES
       IPV4_INCLUDED_ROUTES: 0.0.0.0/0 # optional, demo means proxy all traffic. for multiple network segments, join with `,` or `\n`
       IPV4_EXCLUDED_ROUTES: a.b.c.d # optional, demo means exclude traffic from the proxy itself. for multiple network segments, join with `,` or `\n`
       LOG_LEVEL: warn # optional, default `warn`, other option `debug`/`info`/`error`
-      BYPASS_PBR: 0 # optional, set 1 to ignore TABLE, MARK, IPV4_INCLUDED_ROUTES and IPV4_EXCLUDED_ROUTES
     dns:
       - 8.8.8.8
 ```

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,6 +8,12 @@ IPV6="${IPV6:-}"
 TABLE="${TABLE:-20}"
 MARK="${MARK:-438}"
 
+BYPASS_PBR="${BYPASS_PBR:-0}"
+
+if [ "${BYPASS_PBR}" == "1" ]; then
+  MARK="0"
+fi
+
 SOCKS5_ADDR="${SOCKS5_ADDR:-172.17.0.1}"
 SOCKS5_PORT="${SOCKS5_PORT:-1080}"
 SOCKS5_USERNAME="${SOCKS5_USERNAME:-}"
@@ -48,6 +54,10 @@ EOF
 config_route() {
   echo "#!/bin/sh" > /route.sh
   chmod +x /route.sh
+
+  if [ "${BYPASS_PBR}" == "1" ]; then
+    return
+  fi
 
   echo "ip route add default dev ${TUN} table ${TABLE}" >> /route.sh
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,9 +8,9 @@ IPV6="${IPV6:-}"
 TABLE="${TABLE:-20}"
 MARK="${MARK:-438}"
 
-BYPASS_PBR="${BYPASS_PBR:-0}"
+CONFIG_ROUTES="${CONFIG_ROUTES:-1}"
 
-if [ "${BYPASS_PBR}" == "1" ]; then
+if [ "${CONFIG_ROUTES}" == "0" ]; then
   MARK="0"
 fi
 
@@ -55,7 +55,7 @@ config_route() {
   echo "#!/bin/sh" > /route.sh
   chmod +x /route.sh
 
-  if [ "${BYPASS_PBR}" == "1" ]; then
+  if [ "${CONFIG_ROUTES}" == "0" ]; then
     return
   fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,13 +5,13 @@ MTU="${MTU:-8500}"
 IPV4="${IPV4:-198.18.0.1}"
 IPV6="${IPV6:-}"
 
-TABLE="${TABLE:-20}"
-MARK="${MARK:-438}"
-
 CONFIG_ROUTES="${CONFIG_ROUTES:-1}"
 
+TABLE="${TABLE:-20}"
 if [ "${CONFIG_ROUTES}" == "0" ]; then
-  MARK="0"
+  MARK="${MARK:-0}"
+else
+  MARK="${MARK:-438}"
 fi
 
 SOCKS5_ADDR="${SOCKS5_ADDR:-172.17.0.1}"


### PR DESCRIPTION
Issue #220 

Set environment BYPASS_PBR=1, following settings will be ignored:
* TABLE
* MARK overwrite to 0
* IPV4_INCLUDED_ROUTES
* IPV4_EXCLUDED_ROUTES

`route.sh` will do nothing than writing `/success`

