### PR TITLE
Android : Add documentation and error log for changing package macros

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -30,7 +30,10 @@ SRCDIR := $(LOCAL_PATH)/src
 
 include $(CLEAR_VARS)
 include $(LOCAL_PATH)/build.mk
-LOCAL_MODULE    := hev-socks5-tunnel
+MODULE_NAME := hev-socks5-tunnel
+PKGNAME := hev/htproxy
+CLSNAME := TProxyService
+LOCAL_MODULE    := $(MODULE_NAME)
 LOCAL_SRC_FILES := $(patsubst $(SRCDIR)/%,src/%,$(SRCFILES))
 LOCAL_C_INCLUDES := \
 	$(LOCAL_PATH)/src/misc \
@@ -39,7 +42,8 @@ LOCAL_C_INCLUDES := \
 	$(LOCAL_PATH)/third-part/lwip/src/include \
 	$(LOCAL_PATH)/third-part/lwip/src/ports/include \
 	$(LOCAL_PATH)/third-part/hev-task-system/include
-LOCAL_CFLAGS += -DFD_SET_DEFINED -DSOCKLEN_T_DEFINED $(VERSION_CFLAGS)
+LOCAL_CFLAGS += -DFD_SET_DEFINED -DSOCKLEN_T_DEFINED $(VERSION_CFLAGS) \
+    -DPKGNAME_FROM_MK=\"$(PKGNAME)\" -DCLSNAME_FROM_MK=\"$(CLSNAME)\" -DMODULE_NAME_FROM_MK=\"$(MODULE_NAME)\"
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
 LOCAL_CFLAGS += -mfpu=neon
 endif

--- a/Android.mk
+++ b/Android.mk
@@ -30,10 +30,7 @@ SRCDIR := $(LOCAL_PATH)/src
 
 include $(CLEAR_VARS)
 include $(LOCAL_PATH)/build.mk
-MODULE_NAME := hev-socks5-tunnel
-PKGNAME := hev/htproxy
-CLSNAME := TProxyService
-LOCAL_MODULE    := $(MODULE_NAME)
+LOCAL_MODULE    := hev-socks5-tunnel
 LOCAL_SRC_FILES := $(patsubst $(SRCDIR)/%,src/%,$(SRCFILES))
 LOCAL_C_INCLUDES := \
 	$(LOCAL_PATH)/src/misc \
@@ -42,12 +39,12 @@ LOCAL_C_INCLUDES := \
 	$(LOCAL_PATH)/third-part/lwip/src/include \
 	$(LOCAL_PATH)/third-part/lwip/src/ports/include \
 	$(LOCAL_PATH)/third-part/hev-task-system/include
-LOCAL_CFLAGS += -DFD_SET_DEFINED -DSOCKLEN_T_DEFINED $(VERSION_CFLAGS) \
-    -DPKGNAME_FROM_MK=\"$(PKGNAME)\" -DCLSNAME_FROM_MK=\"$(CLSNAME)\" -DMODULE_NAME_FROM_MK=\"$(MODULE_NAME)\"
+LOCAL_CFLAGS += -DFD_SET_DEFINED -DSOCKLEN_T_DEFINED $(VERSION_CFLAGS)
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
 LOCAL_CFLAGS += -mfpu=neon
 endif
 LOCAL_STATIC_LIBRARIES := yaml lwip hev-task-system
 LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
 LOCAL_LDFLAGS += -Wl,-z,common-page-size=16384
+LOCAL_LDLIBS += -llog
 include $(BUILD_SHARED_LIBRARY)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ git clone --recursive https://github.com/heiher/hev-socks5-tunnel jni
 ndk-build
 ```
 
+> Important
+> If you change the Java package or class name for the Android Service, you must also update the corresponding macros inside [`src/hev-jni.c`](src/hev-jni.c).
+```c
+  #define PKGNAME "hev/htproxy" // your package name, com.yourapp.service -> com/yourapp/service
+  #define CLSNAME "TProxyService" // your Service class name
+```
+
 ### iOS and macOS
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,12 +49,18 @@ git clone --recursive https://github.com/heiher/hev-socks5-tunnel jni
 ndk-build
 ```
 
-> [!IMPORTANT]
-> If you change the Java package or class name for the Android Service, you must also update the corresponding macros inside [`src/hev-jni.c`](src/hev-jni.c).
-```c
-  #define PKGNAME "hev/htproxy" // your package name, com.yourapp.service -> com/yourapp/service
-  #define CLSNAME "TProxyService" // your Service class name
-```
+> [!IMPORTANT] 
+> If you change the Java package or class name for the Android Service, update the following macros in [`src/hev-jni.c`](src/hev-jni.c) to match your Java code:
+>
+> ```c
+> #define PKGNAME "hev/htproxy"    // your package name, e.g. com/yourapp/service -> com/yourapp/service
+> #define CLSNAME "TProxyService"  // your Service class name
+> ```
+>
+> **Usage cases:**
+> - [`sockstun`](https://github.com/heiher/sockstun/blob/2821e37d84ac62027b42b16bb3c80c17e35143d7/app/build.gradle#L20)
+> - [`ByeDPIAndroid`](https://github.com/dovecoteescapee/ByeDPIAndroid/blob/43db0955de687d43f9473374dc7c5548eaa55359/app/src/main/jni/Application.mk#L19)
+
 
 ### iOS and macOS
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ git clone --recursive https://github.com/heiher/hev-socks5-tunnel jni
 ndk-build
 ```
 
-> Important
+> [!IMPORTANT]
 > If you change the Java package or class name for the Android Service, you must also update the corresponding macros inside [`src/hev-jni.c`](src/hev-jni.c).
 ```c
   #define PKGNAME "hev/htproxy" // your package name, com.yourapp.service -> com/yourapp/service

--- a/src/hev-jni.c
+++ b/src/hev-jni.c
@@ -23,10 +23,10 @@
 
 /* clang-format off */
 #ifndef PKGNAME
-#define PKGNAME hev/htproxy
+#define PKGNAME PKGNAME_FROM_MK
 #endif
 #ifndef CLSNAME
-#define CLSNAME TProxyService
+#define CLSNAME CLSNAME_FROM_MK
 #endif
 /* clang-format on */
 

--- a/src/hev-jni.c
+++ b/src/hev-jni.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <string.h>
+#include <android/log.h>
 
 #include "hev-main.h"
 
@@ -23,10 +24,10 @@
 
 /* clang-format off */
 #ifndef PKGNAME
-#define PKGNAME PKGNAME_FROM_MK
+#define PKGNAME "hev/htproxy"
 #endif
 #ifndef CLSNAME
-#define CLSNAME CLSNAME_FROM_MK
+#define CLSNAME "TProxyService"
 #endif
 /* clang-format on */
 
@@ -77,7 +78,11 @@ JNI_OnLoad (JavaVM *vm, void *reserved)
         return 0;
     }
 
-    klass = (*env)->FindClass (env, STR (PKGNAME) "/" STR (CLSNAME));
+    klass = (*env)->FindClass (env, PKGNAME "/" CLSNAME);
+    if (!klass) {
+        __android_log_print(ANDROID_LOG_ERROR, "hev-jni", "ERROR: Could not find Java class %s/%s. If you changed the package or class name in your Android project, update PKGNAME and CLSNAME in src/hev-jni.c to match.", PKGNAME, CLSNAME);
+        return 0;
+    }
     (*env)->RegisterNatives (env, klass, native_methods,
                              N_ELEMENTS (native_methods));
     (*env)->DeleteLocalRef (env, klass);


### PR DESCRIPTION
Moved the package name and classname macros to the Android.mk from hev-jni.c. It's for developers to save time, cause if I tell about my experience with it first time I built it and the app was crashing after loading libs, after few hours of debugging found that I didn't change the package lol. So keeping it inside Android.mk is better I think so devs can easily swap package name and class names and also change the module name easily. Hope that makes sense. Thanks