### PR TITLE
Chore: Optimize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,32 @@
-bin
-build
-HevSocks5Tunnel.xcframework
-obj
-libs
+# Binaries
+bin/
+build/
+obj/
+libs/
+
+# XCFrameworks (for Apple platforms)
+HevSocks5Tunnel.xcframework/
+
+# macOS files
+.DS_Store
+
+# Editor/IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log
+
+# CMake
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+
+# Backup files
+*~
+
+# Generated config
+config.h


### PR DESCRIPTION
This optimized version of `.gitignore` includes, in addition to the previous ones, temporary files and common build folders, IDE and editor files, temporary system files (such as `.DS_Store`), logs, files generated by CMake, and backup files to keep your repository cleaner and prevent unnecessary files from entering git.