### PR TITLE
Fix clone failed

### DIFF
--- a/src/hev-jni.c
+++ b/src/hev-jni.c
@@ -121,7 +121,7 @@ native_start_service (JNIEnv *env, jobject thiz, jstring config_path, jint fd)
     (*env)->ReleaseStringUTFChars (env, config_path, (const char *)bytes);
 
     res = pthread_create (&work_thread, NULL, thread_handler, tdata);
-    if (res < 0) {
+    if (res != 0) {
         free (tdata->path);
         free (tdata);
         goto exit;


### PR DESCRIPTION
Fix a bug while the clone systemcall (which pthread_create really calls) execution failed
See https://man7.org/linux/man-pages/man3/pthread_create.3.html