### PR TITLE
DSN Additional RRs 格式规范

### DIFF
--- a/src/hev-mapped-dns.c
+++ b/src/hev-mapped-dns.c
@@ -193,6 +193,7 @@ hev_mapped_dns_handle (HevMappedDNS *self, void *req, int qlen, void *res,
     shdr->fl = ntohs (shdr->fl);
     shdr->ns = 0;
     shdr->an = 0;
+    shdr->ar = 0;
 
     if (qhdr->qd > 32)
         return -1;


### PR DESCRIPTION
[https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.1](url)
mapdns回复报文中不存在 `Additional`记录，但是mapdns回复报文中`Additional RRs: 1`

### mapdns伪造报文时`Additional RRs: 1`，但是不存在相对可变长度的`Additional`记录，显示以下警告:
**dig 警告：**
<img width="699" height="399" alt="dig_warn" src="https://github.com/user-attachments/assets/037575cd-95f3-42be-ac8e-3f964883cd96" />
**Wireshark警告：**
<img width="884" height="405" alt="Wireshark-warn" src="https://github.com/user-attachments/assets/3aecfc14-be3d-4dbc-b335-7eaa45fa5a77" />




### 符合RFC规范(Additional RRs: 0 && Additional=null):
<img width="880" height="457" alt="ar0" src="https://github.com/user-attachments/assets/4f8201ad-7a2d-439e-a661-e969d9f26175" />



