### PR TITLE
mapdns重构

### DIFF
--- a/src/hev-socks5-tunnel.c
+++ b/src/hev-socks5-tunnel.c
@@ -586,7 +586,7 @@ mapped_dns_init (void)
     if (!cache_size)
         return 0;
 
-    dns = hev_mapped_dns_new (network, netmask, cache_size);
+    dns = hev_mapped_dns_init (network, netmask, cache_size);
     if (!dns)
         return -1;
 
@@ -602,7 +602,7 @@ mapped_dns_fini (void)
 
     dns = hev_mapped_dns_get ();
     if (dns) {
-        hev_object_unref (HEV_OBJECT (dns));
+	hev_mapped_dns_destroy(dns);
         hev_mapped_dns_put (NULL);
     }
 }


### PR DESCRIPTION
在windows 11上使用hev-socks5-tunnel搭建的透明网关时，发现windows 11上系统的dnscache缓存策略不符合rfc规范`ipconfig /displaydns`。windows 11默认dns缓存延长到86400秒。
mapdns对于这种不规范的缓存客户端，需要建立ttl持续时间更长的[ip->domain]映射方法。

### 以下是这个提交的实现原理：
假设 
```
mapdns:
  network: 192.168.1.0
  netmask: 255.255.255.0
  cache-size: 10000
```
**等效于** `192.168.1.0/24`
    1.已知`hev-socks5-tunnel`只需要` [ipv4-> domain]`单向映射。
    2.mapdns可用`ip 192.168.1.0 ~ 192.168.0.255`,，`广播地址 192.168.1.255` `网络地址 192.168.1.0`，实际可用地址 `192.168.1.1 ~ 192.168.1.254`
    3.为了方便管理 每个映射分配一个 `char[256]`，使用位运算 NOT `~netmask`  申请一块` char[~netmask][256]`大小的内存作为环形缓冲区。

**处理流程：**
    1.收到 “github.com”的DNS A请求，分配环形缓冲区首个地址`192.168.1.1`，将DNS请求数据包的域名写入`char[1][256]`
    2.tun设备收到`192.168.1.1`的tcp链接，`（uint32_t)(192.168.1.1 - 192.168.1.0) = index`
    3.取地址运算`&(char[index][0])`  得到映射域名的 char[256]的缓冲区地址，完成ip->域名的映射。

**缺点：**
    1.为了方便管理 每个缓冲区都是rfc1035规定的域名最长值，需要耗费更多的内存 。（每个域名映射256字节）
    2.每个dns请求会分配一个映射块(配合前置缓存服务器，这甚至是个优点) ` [mapdns <- dnsmasq chche]`

**优点：**
    1.避免内存管理的开销，环形缓冲区初始化时申请一次大块内存，直到程序运行结束释放。不存在mapdns运行产生的内存碎片。
    2.快速映射，一些简单的指针运算就能直接得到映射到对应域名 O(1)
    3.更长的TTL，在环形缓冲区对应的char[256]没被覆盖之前，ip映射的域名始终有效。避免不规范的缓存客户端导致的映射失败。

**要点：**
    1.`cache-size`用于限制最大的`char[256]`块数量
         假设`cache-size: 10000  network: 192.168.0.0/16` ~mask =65536 但会被限制为 10000 `char[10000][256]` 大约需要 2.44MiB内存
    2.增加`hev_mapped_dns_cache_ttl`函数，需要作者加入yaml配置选项，可以控制前置缓存的ttl 例如dnsmasq

**因为不太熟练，如果代码中有换行 代码对齐之类的格式问题，麻烦作者合并代码后帮忙修改一下。**
