### PR TITLE
HevTunnelMacos: Infinite loop when network disconnection occurs on macOS

### DIFF
--- a/src/hev-tunnel-macos.h
+++ b/src/hev-tunnel-macos.h
@@ -30,7 +30,7 @@ hev_tunnel_read (int fd, int mtu, HevTaskIOYielder yielder, void *yielder_data)
     iov[1].iov_len = buf->len;
 
     s = hev_task_io_readv (fd, iov, 2, yielder, yielder_data);
-    if (s <= 0) {
+    if (s <= (ssize_t)sizeof (type)) {
         pbuf_free (buf);
         return NULL;
     }
@@ -67,7 +67,7 @@ hev_tunnel_write (int fd, struct pbuf *buf)
     }
 
     res = writev (fd, iov, i);
-    if (res <= sizeof (type))
+    if (res <= (ssize_t)sizeof (type))
         return -1;
 
     return res;


### PR DESCRIPTION
Frequent network switching/on/off cycles can cause the CPU to freeze and prevent the program from exiting. 

Rolling back to b909a6ebc5f55cd94a57b18627700b745c8909a3 resolves the issue; the key problem appears to be getting stuck on packets with s>0.