### PR TITLE
add android arm64 to release build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -215,6 +215,45 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  android:
+    name: Android Arm64
+    runs-on: ubuntu-latest
+    env:
+      API: 24
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          submodules: true
+      - name: Setup NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27d
+      - name: Configure Android toolchain
+        run: |
+          export TOOLCHAIN=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64
+
+          echo "CC=$TOOLCHAIN/bin/aarch64-linux-android${API}-clang" >> $GITHUB_ENV
+          echo "CXX=$TOOLCHAIN/bin/aarch64-linux-android${API}-clang++" >> $GITHUB_ENV
+          echo "AR=$TOOLCHAIN/bin/llvm-ar" >> $GITHUB_ENV
+          echo "RANLIB=$TOOLCHAIN/bin/llvm-ranlib" >> $GITHUB_ENV
+      - name: Build
+        run: |
+          make \
+            CC="$CC" \
+            AR="$AR" \
+            RANLIB="$RANLIB" \
+            -j$(nproc)
+          cp bin/hev-socks5-tunnel hev-socks5-tunnel-android-arm64-v8a
+      - name: Upload
+        uses: actions/upload-artifact@v7
+        with:
+          name: hev-socks5-tunnel-android-arm64-v8a
+          path: hev-socks5-tunnel-android-arm64-v8a
+          if-no-files-found: error
+          retention-days: 1
+
   release:
     name: Release
     runs-on: ubuntu-latest
@@ -224,6 +263,7 @@ jobs:
       - macos
       - freebsd
       - windows
+      - android
     if: github.event_name == 'release'
     steps:
       - name: Checkout
@@ -258,8 +298,8 @@ jobs:
         run: |
           ./build-apple.sh
 
-  android:
-    name: Android
+  android-lib:
+    name: Android Library
     runs-on: ubuntu-latest
     if: github.event_name != 'release'
     steps:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@ PP=$(CROSS_PREFIX)cpp
 CC=$(CROSS_PREFIX)gcc
 AR=$(CROSS_PREFIX)ar
 STRIP=$(CROSS_PREFIX)strip
+
+# Android's Bionic libc already provides pthread functions.
+ifeq ($(findstring android,$(CC)),)
+    PTHREAD_LDFLAG=-lpthread
+else
+    PTHREAD_LDFLAG=
+endif
+
 CCFLAGS=-O3 -pipe -Wall -Werror $(CFLAGS) \
 		-I$(SRCDIR) \
 		-I$(SRCDIR)/misc \
@@ -16,10 +24,11 @@ CCFLAGS=-O3 -pipe -Wall -Werror $(CFLAGS) \
 		-I$(THIRDPARTDIR)/lwip/src/include \
 		-I$(THIRDPARTDIR)/lwip/src/ports/include \
 		-I$(THIRDPARTDIR)/hev-task-system/include
+
 LDFLAGS=-L$(THIRDPARTDIR)/yaml/bin -lyaml \
 		-L$(THIRDPARTDIR)/lwip/bin -llwip \
 		-L$(THIRDPARTDIR)/hev-task-system/bin -lhev-task-system \
-		-lpthread $(LFLAGS)
+		$(PTHREAD_LDFLAG) $(LFLAGS)
 
 SRCDIR=src
 BINDIR=bin


### PR DESCRIPTION
* workflow file: add android arm64 to release build

* MAKEFILE: add conditional check, remove -lpthread when building android arm64 bin.
    * Android's Bionic libc provides pthread functionality inside libc.so, so -lpthread need to be removed.