### PR TITLE
Handle SIGTERM for graceful shutdown and `pre-down-script` execution

### DIFF
--- a/src/hev-main.c
+++ b/src/hev-main.c
@@ -129,7 +129,7 @@ show_help (const char *self_path)
 }
 
 static void
-sigint_handler (int signum)
+sig_handler (int signum)
 {
     hev_socks5_tunnel_stop ();
 }
@@ -144,7 +144,8 @@ main (int argc, char *argv[])
         return -1;
     }
 
-    signal (SIGINT, sigint_handler);
+    signal (SIGINT, sig_handler);
+    signal (SIGTERM, sig_handler);
 
     res = hev_socks5_tunnel_main (argv[1], -1);
     if (res < 0)


### PR DESCRIPTION
Currently, the application only catches `SIGINT` to trigger its graceful shutdown sequence. When the tunnel is managed as a background service by systemd or Docker, it receives a `SIGTERM` signal upon stopping. Because this signal isn't handled, the process terminates abruptly, skipping the resource cleanup and preventing the `pre-down-script` from executing.

This PR registers `SIGTERM` to use the existing `sigint_handler` in `src/hev-main.c`, ensuring consistent cleanup and script execution regardless of how the daemon is stopped.