### PR TITLE
README: add Hey VPN use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,10 @@ void hev_socks5_tunnel_stats (size_t *tx_packets, size_t *tx_bytes,
 
 ## Use Cases
 
+### HarmonyOS NEXT
+
+* [Hey VPN](https://github.com/popsiclelmlm/Hey)
+
 ### Android VPN
 
 * [SocksTun](https://github.com/heiher/sockstun)

--- a/README.md
+++ b/README.md
@@ -363,13 +363,13 @@ void hev_socks5_tunnel_stats (size_t *tx_packets, size_t *tx_bytes,
 
 ## Use Cases
 
-### HarmonyOS NEXT
-
-* [Hey VPN](https://github.com/popsiclelmlm/Hey)
-
 ### Android VPN
 
 * [SocksTun](https://github.com/heiher/sockstun)
+
+### HarmonyOS NEXT
+
+* [Hey VPN](https://github.com/popsiclelmlm/Hey)
 
 ### iOS
 


### PR DESCRIPTION
## Summary
- add Hey VPN to the README use cases under HarmonyOS NEXT
- document a HarmonyOS NEXT project that uses HevSocks5Tunnel for its VPN TUN data path
- https://github.com/popsiclelmlm/Hey/blob/main/THIRD-PARTY-NOTICES.md

## Testing
- not run; docs-only change