### PR TITLE
Update APP_ABI to exclude x86 architectures

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -15,7 +15,7 @@
 
 APP_OPTIM := release
 APP_PLATFORM := android-29
-APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
+APP_ABI := armeabi-v7a arm64-v8a
 APP_CFLAGS := -O3
 APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true
 NDK_TOOLCHAIN_VERSION := clang


### PR DESCRIPTION
Removed x86 and x86_64 from the APP_ABI list.