### PR TITLE
fix(android): expose native runtime state

### DIFF
--- a/src/hev-jni.c
+++ b/src/hev-jni.c
@@ -11,6 +11,7 @@
 
 #include <jni.h>
 #include <pthread.h>
+#include <stdatomic.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,21 +43,24 @@ struct _ThreadData
     int fd;
 };
 
-static int is_working;
+static atomic_int is_running;
+static int thread_joinable;
 static JavaVM *java_vm;
 static pthread_t work_thread;
 static pthread_mutex_t mutex;
 static pthread_key_t current_jni_env;
 
-static void native_start_service (JNIEnv *env, jobject thiz, jstring conig_path,
-                                  jint fd);
-static void native_stop_service (JNIEnv *env, jobject thiz);
+static jboolean native_start_service (JNIEnv *env, jobject thiz,
+                                      jstring conig_path, jint fd);
+static jboolean native_stop_service (JNIEnv *env, jobject thiz);
+static jboolean native_is_running (JNIEnv *env, jobject thiz);
 static jlongArray native_get_stats (JNIEnv *env, jobject thiz);
 
 static JNINativeMethod native_methods[] = {
-    { "TProxyStartService", "(Ljava/lang/String;I)V",
+    { "TProxyStartService", "(Ljava/lang/String;I)Z",
       (void *)native_start_service },
-    { "TProxyStopService", "()V", (void *)native_stop_service },
+    { "TProxyStopService", "()Z", (void *)native_stop_service },
+    { "TProxyIsRunning", "()Z", (void *)native_is_running },
     { "TProxyGetStats", "()[J", (void *)native_get_stats },
 };
 
@@ -95,57 +99,91 @@ thread_handler (void *data)
 
     hev_socks5_tunnel_main (tdata->path, tdata->fd);
 
+    atomic_store_explicit (&is_running, 0, memory_order_release);
+
     free (tdata->path);
     free (tdata);
 
     return NULL;
 }
 
-static void
+static jboolean
 native_start_service (JNIEnv *env, jobject thiz, jstring config_path, jint fd)
 {
     const jbyte *bytes;
     ThreadData *tdata;
     int res;
+    jboolean result = JNI_FALSE;
 
     pthread_mutex_lock (&mutex);
 
-    if (is_working)
+    if (atomic_load_explicit (&is_running, memory_order_acquire))
         goto exit;
 
+    if (thread_joinable) {
+        pthread_join (work_thread, NULL);
+        thread_joinable = 0;
+    }
+
     tdata = malloc (sizeof (ThreadData));
+    if (!tdata)
+        goto exit;
     tdata->fd = fd;
 
     bytes = (const jbyte *)(*env)->GetStringUTFChars (env, config_path, NULL);
+    if (!bytes) {
+        free (tdata);
+        goto exit;
+    }
     tdata->path = strdup ((const char *)bytes);
     (*env)->ReleaseStringUTFChars (env, config_path, (const char *)bytes);
+    if (!tdata->path) {
+        free (tdata);
+        goto exit;
+    }
 
+    atomic_store_explicit (&is_running, 1, memory_order_release);
     res = pthread_create (&work_thread, NULL, thread_handler, tdata);
     if (res != 0) {
+        atomic_store_explicit (&is_running, 0, memory_order_release);
         free (tdata->path);
         free (tdata);
         goto exit;
     }
 
-    is_working = 1;
+    thread_joinable = 1;
+    result = JNI_TRUE;
 exit:
     pthread_mutex_unlock (&mutex);
+    return result;
 }
 
-static void
+static jboolean
 native_stop_service (JNIEnv *env, jobject thiz)
 {
+    int res = 0;
+
     pthread_mutex_lock (&mutex);
 
-    if (!is_working)
+    if (!thread_joinable)
         goto exit;
 
-    hev_socks5_tunnel_quit ();
-    pthread_join (work_thread, NULL);
+    if (atomic_load_explicit (&is_running, memory_order_acquire))
+        hev_socks5_tunnel_quit ();
+    res = pthread_join (work_thread, NULL);
 
-    is_working = 0;
+    thread_joinable = 0;
+    atomic_store_explicit (&is_running, 0, memory_order_release);
 exit:
     pthread_mutex_unlock (&mutex);
+    return res == 0 ? JNI_TRUE : JNI_FALSE;
+}
+
+static jboolean
+native_is_running (JNIEnv *env, jobject thiz)
+{
+    return atomic_load_explicit (&is_running, memory_order_acquire) ? JNI_TRUE :
+                                                                      JNI_FALSE;
 }
 
 static jlongArray


### PR DESCRIPTION
The Android JNI entry points currently return void and expose no native worker liveness state. Kotlin cannot distinguish thread creation failure, a stopped native worker, and normal operation. This change returns success from start/stop, adds `isRunning()`, and makes worker state atomic so the Android runtime-state coordinator can observe native state reliably.